### PR TITLE
Store PDF upload path in GCS

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -96,7 +96,7 @@ export type PDFReaderConfig = {
 
   pdfBinary?: string; // base64-encoded string of the uploaded PDF
   pdfName?: string; // Title of the uploaded PDF file
-
+  pdfStoragePath?: string; // GCS path of uploaded PDF
   pdfURL?: string; // URL of the PDF
 
   mode: PDFReaderMode;


### PR DESCRIPTION
We're uploading PDFs into GCS now and our config needs a field to store this.

Unfortunately we can't just reuse the URL field: since the bucket is private, there's not a stable public URL to download it. We're instead storing the path within a bucket (and the bucket is configured via env variable for dev/prod). 